### PR TITLE
Added filter to get a list of Code Id between an interval defined by two ComplexKeys from the by_type_code_version view

### DIFF
--- a/src/main/kotlin/org/taktik/icure/asyncdao/CodeDAO.kt
+++ b/src/main/kotlin/org/taktik/icure/asyncdao/CodeDAO.kt
@@ -33,6 +33,7 @@ interface CodeDAO : GenericDAO<Code> {
 	fun findCodesByLabel(region: String?, language: String?, type: String?, label: String?, version: String?, paginationOffset: PaginationOffset<List<String?>>): Flow<ViewQueryResultEvent>
 	fun listCodeIdsByLabel(region: String?, language: String?, label: String?): Flow<String>
 	fun listCodeIdsByLabel(region: String?, language: String?, type: String?, label: String?): Flow<String>
+	fun listCodeIdsByTypeCodeVersionInterval(startType: String?, startCode: String?, startVersion: String?, endType: String?, endCode: String?, endVersion: String?): Flow<String>
 	suspend fun isValid(codeType: String, codeCode: String, codeVersion: String?): Boolean
 	suspend fun getCodeByLabel(region: String, label: String, ofType: String, labelLang: List<String> = listOf("fr", "nl")): Code?
 	fun findCodesByQualifiedLinkId(region: String?, linkType: String, linkedId: String?, paginationOffset: PaginationOffset<List<String>>): Flow<ViewQueryResultEvent>

--- a/src/main/kotlin/org/taktik/icure/asyncdao/impl/CodeDAOImpl.kt
+++ b/src/main/kotlin/org/taktik/icure/asyncdao/impl/CodeDAOImpl.kt
@@ -66,7 +66,9 @@ class CodeDAOImpl(
 	@Qualifier("asyncCacheManager") asyncCacheManager: AsyncCacheManager
 ) : CachedDAOImpl<Code>(Code::class.java, couchDbProperties, couchDbDispatcher, idGenerator, asyncCacheManager), CodeDAO {
 
-	val SMALLEST_CHAR = "\u0000"
+	companion object {
+		private const val SMALLEST_CHAR = "\u0000"
+	}
 
 	@View(name = "by_type_code_version", map = "classpath:js/code/By_type_code_version.js", reduce = "_count")
 	override fun listCodesBy(type: String?, code: String?, version: String?): Flow<Code> = flow {

--- a/src/main/kotlin/org/taktik/icure/asyncdao/impl/CodeDAOImpl.kt
+++ b/src/main/kotlin/org/taktik/icure/asyncdao/impl/CodeDAOImpl.kt
@@ -392,9 +392,10 @@ class CodeDAOImpl(
 			endVersion ?: ComplexKey.emptyObject(),
 		)
 		emitAll(
-			client.queryView<String, String>(
+			client.queryView<Array<String>, String>(
 				createQuery(client, "by_type_code_version")
 					.includeDocs(false)
+					.reduce(false)
 					.startKey(from)
 					.endKey(to)
 			).mapNotNull { it.id }

--- a/src/main/kotlin/org/taktik/icure/asyncdao/impl/CodeDAOImpl.kt
+++ b/src/main/kotlin/org/taktik/icure/asyncdao/impl/CodeDAOImpl.kt
@@ -379,6 +379,28 @@ class CodeDAOImpl(
 		)
 	}
 
+	override fun listCodeIdsByTypeCodeVersionInterval(startType: String?, startCode: String?, startVersion: String?, endType: String?, endCode: String?, endVersion: String?): Flow<String> = flow {
+		val client = couchDbDispatcher.getClient(dbInstanceUrl)
+		val from = ComplexKey.of(
+			startType ?: "\u0000",
+			startCode ?: "\u0000",
+			startVersion ?: "\u0000",
+		)
+		val to = ComplexKey.of(
+			endType ?: ComplexKey.emptyObject(),
+			endCode ?: ComplexKey.emptyObject(),
+			endVersion ?: ComplexKey.emptyObject(),
+		)
+		emitAll(
+			client.queryView<String, String>(
+				createQuery(client, "by_type_code_version")
+					.includeDocs(false)
+					.startKey(from)
+					.endKey(to)
+			).mapNotNull { it.id }
+		)
+	}
+
 	override fun listCodeIdsByQualifiedLinkId(linkType: String, linkedId: String?): Flow<String> = flow {
 		val client = couchDbDispatcher.getClient(dbInstanceUrl)
 		val from = ComplexKey.of(

--- a/src/main/kotlin/org/taktik/icure/asyncdao/impl/CodeDAOImpl.kt
+++ b/src/main/kotlin/org/taktik/icure/asyncdao/impl/CodeDAOImpl.kt
@@ -66,6 +66,8 @@ class CodeDAOImpl(
 	@Qualifier("asyncCacheManager") asyncCacheManager: AsyncCacheManager
 ) : CachedDAOImpl<Code>(Code::class.java, couchDbProperties, couchDbDispatcher, idGenerator, asyncCacheManager), CodeDAO {
 
+	val SMALLEST_CHAR = "\u0000"
+
 	@View(name = "by_type_code_version", map = "classpath:js/code/By_type_code_version.js", reduce = "_count")
 	override fun listCodesBy(type: String?, code: String?, version: String?): Flow<Code> = flow {
 		val client = couchDbDispatcher.getClient(dbInstanceUrl)
@@ -117,10 +119,10 @@ class CodeDAOImpl(
 					.reduce(false)
 					.startKey(
 						ComplexKey.of(
-							region ?: "\u0000",
-							type ?: "\u0000",
-							code ?: "\u0000",
-							version ?: "\u0000"
+							region ?: SMALLEST_CHAR,
+							type ?: SMALLEST_CHAR,
+							code ?: SMALLEST_CHAR,
+							version ?: SMALLEST_CHAR
 						)
 					)
 					.endKey(
@@ -265,9 +267,9 @@ class CodeDAOImpl(
 	override fun findCodesByLabel(region: String?, language: String?, label: String?, version: String?, paginationOffset: PaginationOffset<List<String?>>): Flow<ViewQueryResultEvent> {
 		val sanitizedLabel = label?.let { StringUtils.sanitizeString(it) }
 		val from = ComplexKey.of(
-			region ?: "\u0000",
-			language ?: "\u0000",
-			sanitizedLabel ?: "\u0000"
+			region ?: SMALLEST_CHAR,
+			language ?: SMALLEST_CHAR,
+			sanitizedLabel ?: SMALLEST_CHAR
 		)
 
 		val to = ComplexKey.of(
@@ -284,10 +286,10 @@ class CodeDAOImpl(
 	override fun findCodesByLabel(region: String?, language: String?, type: String?, label: String?, version: String?, paginationOffset: PaginationOffset<List<String?>>): Flow<ViewQueryResultEvent> {
 		val sanitizedLabel = label?.let { StringUtils.sanitizeString(it) }
 		val from = ComplexKey.of(
-			region ?: "\u0000",
-			language ?: "\u0000",
-			type ?: "\u0000",
-			sanitizedLabel ?: "\u0000"
+			region ?: SMALLEST_CHAR,
+			language ?: SMALLEST_CHAR,
+			type ?: SMALLEST_CHAR,
+			sanitizedLabel ?: SMALLEST_CHAR
 		)
 
 		val to = ComplexKey.of(
@@ -331,9 +333,9 @@ class CodeDAOImpl(
 		val sanitizedLabel = label?.let { StringUtils.sanitizeString(it) }
 		val from =
 			ComplexKey.of(
-				region ?: "\u0000",
-				language ?: "\u0000",
-				sanitizedLabel ?: "\u0000"
+				region ?: SMALLEST_CHAR,
+				language ?: SMALLEST_CHAR,
+				sanitizedLabel ?: SMALLEST_CHAR
 			)
 
 		val to = ComplexKey.of(
@@ -357,10 +359,10 @@ class CodeDAOImpl(
 		val sanitizedLabel = label?.let { StringUtils.sanitizeString(it) }
 		val from =
 			ComplexKey.of(
-				region ?: "\u0000",
-				language ?: "\u0000",
-				type ?: "\u0000",
-				sanitizedLabel ?: "\u0000"
+				region ?: SMALLEST_CHAR,
+				language ?: SMALLEST_CHAR,
+				type ?: SMALLEST_CHAR,
+				sanitizedLabel ?: SMALLEST_CHAR
 			)
 		val to = ComplexKey.of(
 			if (region == null) ComplexKey.emptyObject() else if (language == null) region + "\ufff0" else region,
@@ -382,9 +384,9 @@ class CodeDAOImpl(
 	override fun listCodeIdsByTypeCodeVersionInterval(startType: String?, startCode: String?, startVersion: String?, endType: String?, endCode: String?, endVersion: String?): Flow<String> = flow {
 		val client = couchDbDispatcher.getClient(dbInstanceUrl)
 		val from = ComplexKey.of(
-			startType ?: "\u0000",
-			startCode ?: "\u0000",
-			startVersion ?: "\u0000",
+			startType ?: SMALLEST_CHAR,
+			startCode ?: SMALLEST_CHAR,
+			startVersion ?: SMALLEST_CHAR,
 		)
 		val to = ComplexKey.of(
 			endType ?: ComplexKey.emptyObject(),

--- a/src/main/kotlin/org/taktik/icure/asynclogic/CodeLogic.kt
+++ b/src/main/kotlin/org/taktik/icure/asynclogic/CodeLogic.kt
@@ -46,6 +46,7 @@ interface CodeLogic : EntityPersister<Code, String> {
 	fun findCodesByLabel(region: String?, language: String?, label: String?, version: String?, paginationOffset: PaginationOffset<List<String?>>): Flow<ViewQueryResultEvent>
 	fun findCodesByLabel(region: String?, language: String?, type: String?, label: String?, version: String?, paginationOffset: PaginationOffset<List<String?>>): Flow<ViewQueryResultEvent>
 	fun listCodeIdsByLabel(region: String?, language: String?, type: String?, label: String?): Flow<String>
+	fun listCodeIdsByTypeCodeVersionInterval(startType: String?, startCode: String?, startVersion: String?, endType: String?, endCode: String?, endVersion: String?): Flow<String>
 	fun findCodesByQualifiedLinkId(region: String?, linkType: String, linkedId: String, pagination: PaginationOffset<List<String>>): Flow<ViewQueryResultEvent>
 	fun listCodeIdsByQualifiedLinkId(linkType: String, linkedId: String?): Flow<String>
 	suspend fun <T : Enum<*>> importCodesFromEnum(e: Class<T>)

--- a/src/main/kotlin/org/taktik/icure/asynclogic/impl/CodeLogicImpl.kt
+++ b/src/main/kotlin/org/taktik/icure/asynclogic/impl/CodeLogicImpl.kt
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.google.common.collect.ImmutableMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.emitAll
@@ -143,6 +144,10 @@ class CodeLogicImpl(private val sessionLogic: AsyncSessionLogic, val codeDAO: Co
 
 	override fun listCodeIdsByLabel(region: String?, language: String?, type: String?, label: String?) = flow<String> {
 		emitAll(codeDAO.listCodeIdsByLabel(region, language, type, label))
+	}
+
+	override fun listCodeIdsByTypeCodeVersionInterval(startType: String?, startCode: String?, startVersion: String?, endType: String?, endCode: String?, endVersion: String?) = flow {
+		emitAll(codeDAO.listCodeIdsByTypeCodeVersionInterval(startType, startCode, startVersion, endType, endCode, endVersion))
 	}
 
 	override fun findCodesByQualifiedLinkId(region: String?, linkType: String, linkedId: String, pagination: PaginationOffset<List<String>>) = flow<ViewQueryResultEvent> {

--- a/src/main/kotlin/org/taktik/icure/asynclogic/impl/CodeLogicImpl.kt
+++ b/src/main/kotlin/org/taktik/icure/asynclogic/impl/CodeLogicImpl.kt
@@ -30,7 +30,6 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.google.common.collect.ImmutableMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.emitAll
@@ -77,9 +76,8 @@ class CodeLogicImpl(private val sessionLogic: AsyncSessionLogic, val codeDAO: Co
 				.singletonSupport(singletonSupport = SingletonSupport.DISABLED)
 				.strictNullChecks(strictNullChecks = false)
 				.build()
-			)
+		)
 	}
-
 
 	override fun getTagTypeCandidates(): List<String> {
 		return listOf("CD-ITEM", "CD-PARAMETER", "CD-CAREPATH", "CD-SEVERITY", "CD-URGENCY", "CD-GYNECOLOGY")
@@ -525,7 +523,6 @@ class CodeLogicImpl(private val sessionLogic: AsyncSessionLogic, val codeDAO: Co
 		} catch (e: BulkUpdateConflictException) {
 			log.error("${e.conflicts.size} conflicts")
 		}
-
 	}
 
 	override fun listCodes(paginationOffset: PaginationOffset<*>?, filterChain: FilterChain<Code>, sort: String?, desc: Boolean?) = flow<ViewQueryResultEvent> {

--- a/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/code/CodeIdsByTypeCodeVersionIntervalFilter.kt
+++ b/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/code/CodeIdsByTypeCodeVersionIntervalFilter.kt
@@ -5,8 +5,8 @@ import org.springframework.stereotype.Service
 import org.taktik.icure.asynclogic.CodeLogic
 import org.taktik.icure.asynclogic.impl.filter.Filter
 import org.taktik.icure.asynclogic.impl.filter.Filters
-import org.taktik.icure.entities.base.Code
 import org.taktik.icure.domain.filter.code.CodeIdsByTypeCodeVersionIntervalFilter
+import org.taktik.icure.entities.base.Code
 
 @Service
 class CodeIdsByTypeCodeVersionIntervalFilter(private val codeLogic: CodeLogic) : Filter<String, Code, CodeIdsByTypeCodeVersionIntervalFilter> {
@@ -21,5 +21,4 @@ class CodeIdsByTypeCodeVersionIntervalFilter(private val codeLogic: CodeLogic) :
 			filter.endVersion
 		)
 	}
-
 }

--- a/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/code/CodeIdsByTypeCodeVersionIntervalFilter.kt
+++ b/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/code/CodeIdsByTypeCodeVersionIntervalFilter.kt
@@ -1,0 +1,25 @@
+package org.taktik.icure.asynclogic.impl.filter.code
+
+import kotlinx.coroutines.flow.Flow
+import org.springframework.stereotype.Service
+import org.taktik.icure.asynclogic.CodeLogic
+import org.taktik.icure.asynclogic.impl.filter.Filter
+import org.taktik.icure.asynclogic.impl.filter.Filters
+import org.taktik.icure.entities.base.Code
+import org.taktik.icure.domain.filter.code.CodeIdsByTypeCodeVersionIntervalFilter
+
+@Service
+class CodeIdsByTypeCodeVersionIntervalFilter(private val codeLogic: CodeLogic) : Filter<String, Code, CodeIdsByTypeCodeVersionIntervalFilter> {
+
+	override fun resolve(filter: CodeIdsByTypeCodeVersionIntervalFilter, context: Filters): Flow<String> {
+		return codeLogic.listCodeIdsByTypeCodeVersionInterval(
+			filter.startType,
+			filter.startCode,
+			filter.startVersion,
+			filter.endType,
+			filter.endCode,
+			filter.endVersion
+		)
+	}
+
+}

--- a/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/user/UsersByPatientIdFilter.kt
+++ b/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/user/UsersByPatientIdFilter.kt
@@ -5,8 +5,8 @@ import org.springframework.stereotype.Service
 import org.taktik.icure.asynclogic.UserLogic
 import org.taktik.icure.asynclogic.impl.filter.Filter
 import org.taktik.icure.asynclogic.impl.filter.Filters
-import org.taktik.icure.entities.User
 import org.taktik.icure.domain.filter.user.UsersByPatientIdFilter
+import org.taktik.icure.entities.User
 
 @Service
 class UsersByPatientIdFilter(private val userLogic: UserLogic) : Filter<String, User, UsersByPatientIdFilter> {

--- a/src/main/kotlin/org/taktik/icure/domain/filter/code/CodeIdsByTypeCodeVersionIntervalFilter.kt
+++ b/src/main/kotlin/org/taktik/icure/domain/filter/code/CodeIdsByTypeCodeVersionIntervalFilter.kt
@@ -1,0 +1,13 @@
+package org.taktik.icure.domain.filter.code
+
+import org.taktik.icure.domain.filter.Filter
+import org.taktik.icure.entities.base.Code
+
+interface CodeIdsByTypeCodeVersionIntervalFilter : Filter<String, Code> {
+	val startType: String?
+	val startCode: String?
+	val startVersion: String?
+	val endType: String?
+	val endCode: String?
+	val endVersion: String?
+}

--- a/src/main/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/CodeController.kt
+++ b/src/main/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/CodeController.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flattenMerge
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.reactor.mono
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
@@ -199,7 +198,6 @@ class CodeController(
 		return codeLogic.findCodeTypes(region, type)
 			.filter { tagTypeCandidates.contains(it) }
 			.injectReactorContext()
-
 	}
 
 	@Operation(summary = "Create a code", description = "Create a code entity. Fields Type, Code and Version are required.")

--- a/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/filter/code/CodeIdsByTypeCodeVersionIntervalFilter.kt
+++ b/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/filter/code/CodeIdsByTypeCodeVersionIntervalFilter.kt
@@ -1,0 +1,25 @@
+package org.taktik.icure.services.external.rest.v1.dto.filter.code
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.github.pozo.KotlinBuilder
+import org.taktik.icure.entities.base.Code
+import org.taktik.icure.handlers.JsonPolymorphismRoot
+import org.taktik.icure.services.external.rest.v1.dto.filter.AbstractFilterDto
+
+@JsonPolymorphismRoot(AbstractFilterDto::class)
+@JsonDeserialize(using = JsonDeserializer.None::class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@KotlinBuilder
+data class CodeIdsByTypeCodeVersionIntervalFilter (
+	override val desc: String? = null,
+	override val startType: String? = null,
+	override val startCode: String? = null,
+	override val startVersion: String? = null,
+	override val endType: String? = null,
+	override val endCode: String? = null,
+	override val endVersion: String? = null
+) : AbstractFilterDto<Code>, org.taktik.icure.domain.filter.code.CodeIdsByTypeCodeVersionIntervalFilter

--- a/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/filter/code/CodeIdsByTypeCodeVersionIntervalFilter.kt
+++ b/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/filter/code/CodeIdsByTypeCodeVersionIntervalFilter.kt
@@ -14,7 +14,7 @@ import org.taktik.icure.services.external.rest.v1.dto.filter.AbstractFilterDto
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @KotlinBuilder
-data class CodeIdsByTypeCodeVersionIntervalFilter (
+data class CodeIdsByTypeCodeVersionIntervalFilter(
 	override val desc: String? = null,
 	override val startType: String? = null,
 	override val startCode: String? = null,

--- a/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/filter/user/UsersByPatientIdFilter.kt
+++ b/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/filter/user/UsersByPatientIdFilter.kt
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.github.pozo.KotlinBuilder
-import org.taktik.icure.domain.filter.Filters
 import org.taktik.icure.entities.User
 import org.taktik.icure.handlers.JsonPolymorphismRoot
 import org.taktik.icure.services.external.rest.v1.dto.filter.AbstractFilterDto

--- a/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/filter/code/CodeIdsByTypeCodeVersionIntervalFilter.kt
+++ b/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/filter/code/CodeIdsByTypeCodeVersionIntervalFilter.kt
@@ -14,7 +14,7 @@ import org.taktik.icure.services.external.rest.v2.dto.filter.AbstractFilterDto
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @KotlinBuilder
-data class CodeIdsByTypeCodeVersionIntervalFilter (
+data class CodeIdsByTypeCodeVersionIntervalFilter(
 	override val desc: String? = null,
 	override val startType: String? = null,
 	override val startCode: String? = null,

--- a/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/filter/code/CodeIdsByTypeCodeVersionIntervalFilter.kt
+++ b/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/filter/code/CodeIdsByTypeCodeVersionIntervalFilter.kt
@@ -1,0 +1,25 @@
+package org.taktik.icure.services.external.rest.v2.dto.filter.code
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.github.pozo.KotlinBuilder
+import org.taktik.icure.entities.base.Code
+import org.taktik.icure.handlers.JsonPolymorphismRoot
+import org.taktik.icure.services.external.rest.v2.dto.filter.AbstractFilterDto
+
+@JsonPolymorphismRoot(AbstractFilterDto::class)
+@JsonDeserialize(using = JsonDeserializer.None::class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@KotlinBuilder
+data class CodeIdsByTypeCodeVersionIntervalFilter (
+	override val desc: String? = null,
+	override val startType: String? = null,
+	override val startCode: String? = null,
+	override val startVersion: String? = null,
+	override val endType: String? = null,
+	override val endCode: String? = null,
+	override val endVersion: String? = null
+) : AbstractFilterDto<Code>, org.taktik.icure.domain.filter.code.CodeIdsByTypeCodeVersionIntervalFilter

--- a/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/filter/user/UsersByPatientIdFilter.kt
+++ b/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/filter/user/UsersByPatientIdFilter.kt
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.github.pozo.KotlinBuilder
-import org.taktik.icure.domain.filter.Filters
 import org.taktik.icure.entities.User
 import org.taktik.icure.handlers.JsonPolymorphismRoot
 import org.taktik.icure.services.external.rest.v2.dto.filter.AbstractFilterDto

--- a/src/test/kotlin/org/taktik/icure/asynclogic/UserLogicImplTest.kt
+++ b/src/test/kotlin/org/taktik/icure/asynclogic/UserLogicImplTest.kt
@@ -1,5 +1,6 @@
 package org.taktik.icure.asynclogic
 
+import java.util.UUID
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -16,92 +17,91 @@ import org.taktik.icure.asynclogic.impl.UserLogicImpl
 import org.taktik.icure.db.PaginationOffset
 import org.taktik.icure.entities.User
 import org.taktik.icure.properties.CouchDbProperties
-import java.util.UUID
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class UserLogicImplTest {
-    private val couchDbProperties = mockk<CouchDbProperties>(relaxed = true)
-    private val roleDAO = mockk<RoleDAO>(relaxed = true)
-    private val sessionLogic = mockk<AsyncSessionLogic>(relaxed = true)
-    private val filters = mockk<org.taktik.icure.asynclogic.impl.filter.Filters>(relaxed = true)
-    private val healthcarePartyLogic = mockk<HealthcarePartyLogic>(relaxed = true)
-    private val propertyLogic = mockk<PropertyLogic>(relaxed = true)
-    private val passwordEncoder = mockk<PasswordEncoder>(relaxed = true)
-    private val uuidGenerator = mockk<UUIDGenerator>(relaxed = true)
+	private val couchDbProperties = mockk<CouchDbProperties>(relaxed = true)
+	private val roleDAO = mockk<RoleDAO>(relaxed = true)
+	private val sessionLogic = mockk<AsyncSessionLogic>(relaxed = true)
+	private val filters = mockk<org.taktik.icure.asynclogic.impl.filter.Filters>(relaxed = true)
+	private val healthcarePartyLogic = mockk<HealthcarePartyLogic>(relaxed = true)
+	private val propertyLogic = mockk<PropertyLogic>(relaxed = true)
+	private val passwordEncoder = mockk<PasswordEncoder>(relaxed = true)
+	private val uuidGenerator = mockk<UUIDGenerator>(relaxed = true)
 
-    private val userDAO = mockk<UserDAO>()
-    private val userLogic: UserLogic = UserLogicImpl(couchDbProperties = couchDbProperties, roleDao = roleDAO, sessionLogic = sessionLogic, filters = filters, userDAO = userDAO, healthcarePartyLogic = healthcarePartyLogic, propertyLogic = propertyLogic, passwordEncoder = passwordEncoder, uuidGenerator = uuidGenerator)
+	private val userDAO = mockk<UserDAO>()
+	private val userLogic: UserLogic = UserLogicImpl(couchDbProperties = couchDbProperties, roleDao = roleDAO, sessionLogic = sessionLogic, filters = filters, userDAO = userDAO, healthcarePartyLogic = healthcarePartyLogic, propertyLogic = propertyLogic, passwordEncoder = passwordEncoder, uuidGenerator = uuidGenerator)
 
-    private val patientUser = mockk<ViewRowWithDoc<*, *, *>>{
-        every { (doc as User).patientId } returns UUID.randomUUID().toString()
-        every { (doc as User).healthcarePartyId } returns null
-    }
+	private val patientUser = mockk<ViewRowWithDoc<*, *, *>> {
+		every { (doc as User).patientId } returns UUID.randomUUID().toString()
+		every { (doc as User).healthcarePartyId } returns null
+	}
 
-    private val hcpUser = mockk<ViewRowWithDoc<*, *, *>>{
-        every { (doc as User).healthcarePartyId } returns UUID.randomUUID().toString()
-        every { (doc as User).patientId } returns null
-    }
+	private val hcpUser = mockk<ViewRowWithDoc<*, *, *>> {
+		every { (doc as User).healthcarePartyId } returns UUID.randomUUID().toString()
+		every { (doc as User).patientId } returns null
+	}
 
-    private val hcpAndPatientUser = mockk<ViewRowWithDoc<*, *, *>>{
-        every { (doc as User).healthcarePartyId } returns UUID.randomUUID().toString()
-        every { (doc as User).patientId } returns UUID.randomUUID().toString()
-    }
+	private val hcpAndPatientUser = mockk<ViewRowWithDoc<*, *, *>> {
+		every { (doc as User).healthcarePartyId } returns UUID.randomUUID().toString()
+		every { (doc as User).patientId } returns UUID.randomUUID().toString()
+	}
 
-    private val user = mockk<ViewRowWithDoc<*, *, *>>{
-        every { (doc as User).healthcarePartyId } returns null
-        every { (doc as User).patientId } returns null
-    }
+	private val user = mockk<ViewRowWithDoc<*, *, *>> {
+		every { (doc as User).healthcarePartyId } returns null
+		every { (doc as User).patientId } returns null
+	}
 
-    private val paginationOffset = PaginationOffset<String>(1000)
-    private val extendedLimit = (1000 * 1F).toInt()
+	private val paginationOffset = PaginationOffset<String>(1000)
+	private val extendedLimit = (1000 * 1F).toInt()
 
-    @Test
-    fun `listUser with skipPatients = false, user has only a patientId, Should be found`() {
-        val skipPatient = false
-        every { userDAO.findUsers(paginationOffset, extendedLimit, skipPatient) } returns flowOf(patientUser)
+	@Test
+	fun `listUser with skipPatients = false, user has only a patientId, Should be found`() {
+		val skipPatient = false
+		every { userDAO.findUsers(paginationOffset, extendedLimit, skipPatient) } returns flowOf(patientUser)
 
-        runBlocking {
-            assert(userLogic.listUsers(paginationOffset, skipPatient).toList().filterIsInstance<ViewRowWithDoc<*, *, *>>().single() === patientUser)
-        }
-    }
+		runBlocking {
+			assert(userLogic.listUsers(paginationOffset, skipPatient).toList().filterIsInstance<ViewRowWithDoc<*, *, *>>().single() === patientUser)
+		}
+	}
 
-    @Test
-    fun `listUser with skipPatients = true, user has only a patientId, Should not be found`() {
-        val skipPatient = true
-        every { userDAO.findUsers(paginationOffset, extendedLimit, skipPatient) } returns flowOf(patientUser)
+	@Test
+	fun `listUser with skipPatients = true, user has only a patientId, Should not be found`() {
+		val skipPatient = true
+		every { userDAO.findUsers(paginationOffset, extendedLimit, skipPatient) } returns flowOf(patientUser)
 
-        runBlocking {
-            assert(userLogic.listUsers(paginationOffset, skipPatient).toList().filterIsInstance<ViewRowWithDoc<*, *, *>>().isEmpty())
-        }
-    }
+		runBlocking {
+			assert(userLogic.listUsers(paginationOffset, skipPatient).toList().filterIsInstance<ViewRowWithDoc<*, *, *>>().isEmpty())
+		}
+	}
 
-    @Test
-    fun `listUser with skipPatients = true, user has only a hcpId, Should be found`() {
-        val skipPatient = true
-        every { userDAO.findUsers(paginationOffset, extendedLimit, skipPatient) } returns flowOf(hcpUser)
+	@Test
+	fun `listUser with skipPatients = true, user has only a hcpId, Should be found`() {
+		val skipPatient = true
+		every { userDAO.findUsers(paginationOffset, extendedLimit, skipPatient) } returns flowOf(hcpUser)
 
-        runBlocking {
-            assert(userLogic.listUsers(paginationOffset, skipPatient).toList().filterIsInstance<ViewRowWithDoc<*, *, *>>().single() === hcpUser)
-        }
-    }
+		runBlocking {
+			assert(userLogic.listUsers(paginationOffset, skipPatient).toList().filterIsInstance<ViewRowWithDoc<*, *, *>>().single() === hcpUser)
+		}
+	}
 
-    @Test
-    fun `listUser with skipPatients = true, user has a patientId AND a hcpId, Should be found`() {
-        val skipPatient = true
-        every { userDAO.findUsers(paginationOffset, extendedLimit, skipPatient) } returns flowOf(hcpAndPatientUser)
+	@Test
+	fun `listUser with skipPatients = true, user has a patientId AND a hcpId, Should be found`() {
+		val skipPatient = true
+		every { userDAO.findUsers(paginationOffset, extendedLimit, skipPatient) } returns flowOf(hcpAndPatientUser)
 
-        runBlocking {
-            assert(userLogic.listUsers(paginationOffset, skipPatient).toList().filterIsInstance<ViewRowWithDoc<*, *, *>>().single() === hcpAndPatientUser)
-        }
-    }
+		runBlocking {
+			assert(userLogic.listUsers(paginationOffset, skipPatient).toList().filterIsInstance<ViewRowWithDoc<*, *, *>>().single() === hcpAndPatientUser)
+		}
+	}
 
-    @Test
-    fun `listUser with skipPatients = true, user has no patientId AND no hcpId, Should be found`() {
-        val skipPatient = true
-        every { userDAO.findUsers(paginationOffset, extendedLimit, skipPatient) } returns flowOf(user)
+	@Test
+	fun `listUser with skipPatients = true, user has no patientId AND no hcpId, Should be found`() {
+		val skipPatient = true
+		every { userDAO.findUsers(paginationOffset, extendedLimit, skipPatient) } returns flowOf(user)
 
-        runBlocking {
-            assert(userLogic.listUsers(paginationOffset, skipPatient).toList().filterIsInstance<ViewRowWithDoc<*, *, *>>().single() === user)
-        }
-    }
+		runBlocking {
+			assert(userLogic.listUsers(paginationOffset, skipPatient).toList().filterIsInstance<ViewRowWithDoc<*, *, *>>().single() === user)
+		}
+	}
 }

--- a/src/test/kotlin/org/taktik/icure/asynclogic/codelogic/CodeLogicListCodeIdsByTypeCodeVersionIntervalTest.kt
+++ b/src/test/kotlin/org/taktik/icure/asynclogic/codelogic/CodeLogicListCodeIdsByTypeCodeVersionIntervalTest.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.module.kotlin.SingletonSupport
 import kotlinx.coroutines.flow.fold
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -14,7 +15,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.taktik.icure.asynclogic.CodeLogic
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.taktik.icure.services.external.rest.v1.mapper.base.CodeMapper
 import org.taktik.icure.test.CodeBatchGenerator
 import org.taktik.icure.test.ICureTestApplication
@@ -68,7 +68,7 @@ class CodeLogicListCodeIdsByTypeCodeVersionIntervalTest @Autowired constructor(
 					assert(testBatchIds.contains(it))
 					acc + 1
 				}
-			assertEquals(testBatchIds.size-startIndex, idsCount)
+			assertEquals(testBatchIds.size - startIndex, idsCount)
 		}
 	}
 
@@ -82,15 +82,15 @@ class CodeLogicListCodeIdsByTypeCodeVersionIntervalTest @Autowired constructor(
 					assert(testBatchIds.contains(it))
 					acc + 1
 				}
-			assertEquals(endIndex+1, idsCount)
+			assertEquals(endIndex + 1, idsCount)
 		}
 	}
 
 	@Test
 	fun ifStartKeyAndEndKeyAreSpecifiedAllTheInBetweenCodesAreReturned() {
 		runBlocking {
-			val startIndex = nextInt(0, testBatchIds.size/2)
-			val endIndex = nextInt(testBatchIds.size/2, testBatchIds.size)
+			val startIndex = nextInt(0, testBatchIds.size / 2)
+			val endIndex = nextInt(testBatchIds.size / 2, testBatchIds.size)
 			val startCode = testBatch[testBatchIds[startIndex]]!!
 			val endCode = testBatch[testBatchIds[endIndex]]!!
 			val idsCount = codeLogic.listCodeIdsByTypeCodeVersionInterval(startCode.type, startCode.code, startCode.version, endCode.type, endCode.code, endCode.version)
@@ -98,7 +98,7 @@ class CodeLogicListCodeIdsByTypeCodeVersionIntervalTest @Autowired constructor(
 					assert(testBatchIds.contains(it))
 					acc + 1
 				}
-			assertEquals(endIndex+1-startIndex, idsCount)
+			assertEquals(endIndex + 1 - startIndex, idsCount)
 		}
 	}
 

--- a/src/test/kotlin/org/taktik/icure/asynclogic/codelogic/CodeLogicListCodeIdsByTypeCodeVersionIntervalTest.kt
+++ b/src/test/kotlin/org/taktik/icure/asynclogic/codelogic/CodeLogicListCodeIdsByTypeCodeVersionIntervalTest.kt
@@ -8,6 +8,9 @@ import kotlinx.coroutines.flow.fold
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
+import kotlinx.coroutines.flow.fold
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance

--- a/src/test/kotlin/org/taktik/icure/asynclogic/codelogic/CodeLogicListCodeIdsByTypeCodeVersionIntervalTest.kt
+++ b/src/test/kotlin/org/taktik/icure/asynclogic/codelogic/CodeLogicListCodeIdsByTypeCodeVersionIntervalTest.kt
@@ -1,0 +1,84 @@
+package org.taktik.icure.asynclogic.codelogic
+
+import kotlin.random.Random.Default.nextInt
+import kotlinx.coroutines.flow.fold
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.taktik.icure.asynclogic.CodeLogic
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.taktik.icure.services.external.rest.v1.mapper.base.CodeMapper
+import org.taktik.icure.test.CodeBatchGenerator
+import org.taktik.icure.test.ICureTestApplication
+
+@SpringBootTest(
+	classes = [ICureTestApplication::class],
+	properties = ["spring.main.allow-bean-definition-overriding=true"],
+	webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+@ActiveProfiles("app")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CodeLogicListCodeIdsByTypeCodeVersionIntervalTest @Autowired constructor(
+	private val codeLogic: CodeLogic,
+	private val codeMapper: CodeMapper
+) {
+
+	private val testBatchSize = 100
+	private val codeGenerator = CodeBatchGenerator()
+	private val testBatch = codeGenerator.createBatchOfUniqueCodes(testBatchSize).associateBy { it.id }
+	private val testBatchIds = testBatch.keys.toSortedSet().toList()
+
+	@BeforeAll
+	fun importTestCodeBatch() {
+		runBlocking {
+			testBatch.values.forEach {
+				codeLogic.create(codeMapper.map(it))
+			}
+		}
+	}
+
+	@Test
+	fun allTheIdsAreReturnedIfBothKeysAreNull() {
+		runBlocking {
+			val idsCount = codeLogic.listCodeIdsByTypeCodeVersionInterval(null, null, null, null, null, null)
+				.fold(0) { acc, it ->
+					assert(testBatchIds.contains(it))
+					acc + 1
+				}
+			assertEquals(testBatchIds.size, idsCount)
+		}
+	}
+
+	@Test
+	fun ifStartKeyIsSpecifiedOnlyResultsThatComeAfterAreReturned() {
+		runBlocking {
+			val startIndex = nextInt(0, testBatchIds.size)
+			val startCode = testBatch[testBatchIds[startIndex]]!!
+			val idsCount = codeLogic.listCodeIdsByTypeCodeVersionInterval(startCode.type, startCode.code, startCode.version, null, null, null)
+				.fold(0) { acc, it ->
+					assert(testBatchIds.contains(it))
+					acc + 1
+				}
+			assertEquals(testBatchIds.size-startIndex, idsCount)
+		}
+	}
+
+	@Test
+	fun ifEndKeyIsSpecifiedOnlyResultsThatComeAfterAreReturned() {
+		runBlocking {
+			val endIndex = nextInt(0, testBatchIds.size)
+			val endCode = testBatch[testBatchIds[endIndex]]!!
+			val idsCount = codeLogic.listCodeIdsByTypeCodeVersionInterval(null, null, null, endCode.type, endCode.code, endCode.version)
+				.fold(0) { acc, it ->
+					assert(testBatchIds.contains(it))
+					acc + 1
+				}
+			assertEquals(testBatchIds.size-endIndex, idsCount)
+		}
+	}
+}

--- a/src/test/kotlin/org/taktik/icure/asynclogic/impl/filter/code/CodeIdsByTypeCodeVersionIntervalFilterTest.kt
+++ b/src/test/kotlin/org/taktik/icure/asynclogic/impl/filter/code/CodeIdsByTypeCodeVersionIntervalFilterTest.kt
@@ -15,11 +15,11 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.taktik.icure.asynclogic.CodeLogic
-import org.taktik.icure.test.ICureTestApplication
 import org.taktik.icure.asynclogic.impl.filter.Filters
+import org.taktik.icure.services.external.rest.v1.dto.filter.code.CodeIdsByTypeCodeVersionIntervalFilter
 import org.taktik.icure.services.external.rest.v1.mapper.base.CodeMapper
 import org.taktik.icure.test.CodeBatchGenerator
-import org.taktik.icure.services.external.rest.v1.dto.filter.code.CodeIdsByTypeCodeVersionIntervalFilter
+import org.taktik.icure.test.ICureTestApplication
 import org.taktik.icure.test.removeEntities
 
 @SpringBootTest(
@@ -33,7 +33,7 @@ class CodeIdsByTypeCodeVersionIntervalFilterTest @Autowired constructor(
 	private val filters: Filters,
 	private val codeLogic: CodeLogic,
 	private val codeMapper: CodeMapper
-){
+) {
 
 	private val testBatchSize = 1001
 	private val codeGenerator = CodeBatchGenerator()
@@ -126,5 +126,4 @@ class CodeIdsByTypeCodeVersionIntervalFilterTest @Autowired constructor(
 			assert(true)
 		}
 	}
-
 }

--- a/src/test/kotlin/org/taktik/icure/asynclogic/impl/filter/code/CodeIdsByTypeCodeVersionIntervalFilterTest.kt
+++ b/src/test/kotlin/org/taktik/icure/asynclogic/impl/filter/code/CodeIdsByTypeCodeVersionIntervalFilterTest.kt
@@ -38,7 +38,8 @@ class CodeIdsByTypeCodeVersionIntervalFilterTest @Autowired constructor(
 	private val testBatchSize = 1001
 	private val codeGenerator = CodeBatchGenerator()
 	private val testBatch = codeGenerator.createBatchOfUniqueCodes(testBatchSize).associateBy { it.id }
-	private val testBatchIds = testBatch.keys.toSortedSet().toList()
+	@OptIn(ExperimentalStdlibApi::class)
+	private val testBatchIds = testBatch.keys.toSortedSet(compareBy { it.lowercase() }).toList()
 
 	@BeforeAll
 	fun importTestCodeBatch() {
@@ -67,7 +68,7 @@ class CodeIdsByTypeCodeVersionIntervalFilterTest @Autowired constructor(
 		runBlocking {
 			val startIndex = Random.nextInt(0, testBatchIds.size)
 			val startCode = testBatch[testBatchIds[startIndex]]!!
-			val intervalFilter = CodeIdsByTypeCodeVersionIntervalFilter(null, startCode.type, startCode.code, startCode.version, null, null, null)
+			val intervalFilter = CodeIdsByTypeCodeVersionIntervalFilter(startType = startCode.type, startCode = startCode.code, startVersion = startCode.version)
 			val idsCount = filters.resolve(intervalFilter)
 				.fold(0) { acc, it ->
 					assert(testBatchIds.contains(it))
@@ -82,7 +83,7 @@ class CodeIdsByTypeCodeVersionIntervalFilterTest @Autowired constructor(
 		runBlocking {
 			val endIndex = Random.nextInt(0, testBatchIds.size)
 			val endCode = testBatch[testBatchIds[endIndex]]!!
-			val intervalFilter = CodeIdsByTypeCodeVersionIntervalFilter(null, null, null, null, endCode.type, endCode.code, endCode.version)
+			val intervalFilter = CodeIdsByTypeCodeVersionIntervalFilter(endType = endCode.type, endCode = endCode.code, endVersion = endCode.version)
 			val idsCount = filters.resolve(intervalFilter)
 				.fold(0) { acc, it ->
 					assert(testBatchIds.contains(it))

--- a/src/test/kotlin/org/taktik/icure/asynclogic/impl/filter/code/CodeIdsByTypeCodeVersionIntervalFilterTest.kt
+++ b/src/test/kotlin/org/taktik/icure/asynclogic/impl/filter/code/CodeIdsByTypeCodeVersionIntervalFilterTest.kt
@@ -124,7 +124,6 @@ class CodeIdsByTypeCodeVersionIntervalFilterTest @Autowired constructor(
 					.build()
 			)
 			removeEntities(testBatchIds, objectMapper)
-			assert(true)
 		}
 	}
 }

--- a/src/test/kotlin/org/taktik/icure/asynclogic/impl/filter/code/CodeIdsByTypeCodeVersionIntervalFilterTest.kt
+++ b/src/test/kotlin/org/taktik/icure/asynclogic/impl/filter/code/CodeIdsByTypeCodeVersionIntervalFilterTest.kt
@@ -1,0 +1,130 @@
+package org.taktik.icure.asynclogic.impl.filter.code
+
+import kotlin.random.Random
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.SingletonSupport
+import kotlinx.coroutines.flow.fold
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.taktik.icure.asynclogic.CodeLogic
+import org.taktik.icure.test.ICureTestApplication
+import org.taktik.icure.asynclogic.impl.filter.Filters
+import org.taktik.icure.services.external.rest.v1.mapper.base.CodeMapper
+import org.taktik.icure.test.CodeBatchGenerator
+import org.taktik.icure.services.external.rest.v1.dto.filter.code.CodeIdsByTypeCodeVersionIntervalFilter
+import org.taktik.icure.test.removeEntities
+
+@SpringBootTest(
+	classes = [ICureTestApplication::class],
+	properties = ["spring.main.allow-bean-definition-overriding=true"],
+	webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+@ActiveProfiles("app")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CodeIdsByTypeCodeVersionIntervalFilterTest @Autowired constructor(
+	private val filters: Filters,
+	private val codeLogic: CodeLogic,
+	private val codeMapper: CodeMapper
+){
+
+	private val testBatchSize = 1001
+	private val codeGenerator = CodeBatchGenerator()
+	private val testBatch = codeGenerator.createBatchOfUniqueCodes(testBatchSize).associateBy { it.id }
+	private val testBatchIds = testBatch.keys.toSortedSet().toList()
+
+	@BeforeAll
+	fun importTestCodeBatch() {
+		runBlocking {
+			testBatch.values.forEach {
+				codeLogic.create(codeMapper.map(it))
+			}
+		}
+	}
+
+	@Test
+	fun allTheIdsAreReturnedIfBothKeysAreNull() {
+		runBlocking {
+			val intervalFilter = CodeIdsByTypeCodeVersionIntervalFilter()
+			val idsCount = filters.resolve(intervalFilter)
+				.fold(0) { acc, it ->
+					assert(testBatchIds.contains(it))
+					acc + 1
+				}
+			Assertions.assertEquals(testBatchIds.size, idsCount)
+		}
+	}
+
+	@Test
+	fun ifStartKeyIsSpecifiedOnlyResultsThatComeAfterAreReturned() {
+		runBlocking {
+			val startIndex = Random.nextInt(0, testBatchIds.size)
+			val startCode = testBatch[testBatchIds[startIndex]]!!
+			val intervalFilter = CodeIdsByTypeCodeVersionIntervalFilter(null, startCode.type, startCode.code, startCode.version, null, null, null)
+			val idsCount = filters.resolve(intervalFilter)
+				.fold(0) { acc, it ->
+					assert(testBatchIds.contains(it))
+					acc + 1
+				}
+			Assertions.assertEquals(testBatchIds.size - startIndex, idsCount)
+		}
+	}
+
+	@Test
+	fun ifEndKeyIsSpecifiedOnlyResultsThatComeAfterAreReturned() {
+		runBlocking {
+			val endIndex = Random.nextInt(0, testBatchIds.size)
+			val endCode = testBatch[testBatchIds[endIndex]]!!
+			val intervalFilter = CodeIdsByTypeCodeVersionIntervalFilter(null, null, null, null, endCode.type, endCode.code, endCode.version)
+			val idsCount = filters.resolve(intervalFilter)
+				.fold(0) { acc, it ->
+					assert(testBatchIds.contains(it))
+					acc + 1
+				}
+			Assertions.assertEquals(endIndex + 1, idsCount)
+		}
+	}
+
+	@Test
+	fun ifStartKeyAndEndKeyAreSpecifiedAllTheInBetweenCodesAreReturned() {
+		runBlocking {
+			val startIndex = Random.nextInt(0, testBatchIds.size / 2)
+			val endIndex = Random.nextInt(testBatchIds.size / 2, testBatchIds.size)
+			val startCode = testBatch[testBatchIds[startIndex]]!!
+			val endCode = testBatch[testBatchIds[endIndex]]!!
+			val intervalFilter = CodeIdsByTypeCodeVersionIntervalFilter(null, startCode.type, startCode.code, startCode.version, endCode.type, endCode.code, endCode.version)
+			val idsCount = filters.resolve(intervalFilter)
+				.fold(0) { acc, it ->
+					assert(testBatchIds.contains(it))
+					acc + 1
+				}
+			Assertions.assertEquals(endIndex + 1 - startIndex, idsCount)
+		}
+	}
+
+	@AfterAll
+	fun cleanCodes() {
+		runBlocking {
+			val objectMapper = ObjectMapper().registerModule(
+				KotlinModule.Builder()
+					.nullIsSameAsDefault(nullIsSameAsDefault = false)
+					.reflectionCacheSize(reflectionCacheSize = 512)
+					.nullToEmptyMap(nullToEmptyMap = false)
+					.nullToEmptyCollection(nullToEmptyCollection = false)
+					.singletonSupport(singletonSupport = SingletonSupport.DISABLED)
+					.strictNullChecks(strictNullChecks = false)
+					.build()
+			)
+			removeEntities(testBatchIds, objectMapper)
+			assert(true)
+		}
+	}
+
+}

--- a/src/test/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/CodeControllerEndToEndTest.kt
+++ b/src/test/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/CodeControllerEndToEndTest.kt
@@ -2,30 +2,30 @@ package org.taktik.icure.services.external.rest.v1.controllers.core
 
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
+import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.SingletonSupport
-import com.fasterxml.jackson.core.type.TypeReference
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.web.server.LocalServerPort
-import org.springframework.test.context.ActiveProfiles
-import reactor.netty.http.client.HttpClient
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.web.server.LocalServerPort
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver
+import org.springframework.test.context.ActiveProfiles
 import org.taktik.icure.asynclogic.CodeLogic
 import org.taktik.icure.entities.base.Code
 import org.taktik.icure.services.external.rest.v1.dto.CodeDto
 import org.taktik.icure.services.external.rest.v1.dto.PaginatedList
 import org.taktik.icure.test.ICureTestApplication
 import org.taktik.icure.test.removeEntities
+import reactor.netty.http.client.HttpClient
 
 @SpringBootTest(
 	classes = [ICureTestApplication::class],
@@ -36,7 +36,7 @@ import org.taktik.icure.test.removeEntities
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class CodeControllerEndToEndTest @Autowired constructor(
 	private val codeLogic: CodeLogic
-	) {
+) {
 
 	@LocalServerPort
 	var port = 0
@@ -75,7 +75,7 @@ class CodeControllerEndToEndTest @Autowired constructor(
 
 		val countVersions = mutableMapOf<String, MutableList<String>>()
 		resolver.getResources("classpath*:/org/taktik/icure/db/codes/codes-test-version-filter.json").forEach {
-			objectMapper?.readValue(it.inputStream, object: TypeReference<List<Code>>() {})?.forEach { code ->
+			objectMapper?.readValue(it.inputStream, object : TypeReference<List<Code>>() {})?.forEach { code ->
 				codesStats["total"] = (codesStats["total"] as Int) + 1
 				(codesStats["count"] as MutableMap<String, Int>)[code.version ?: "NO_VERSION"] = (codesStats["count"] as Map<String, Int>)[code.version ?: "NO_VERSION"]?.plus(1) ?: 1
 				codesStats["ids"] = (codesStats["ids"] as List<String>) + code.id
@@ -83,10 +83,9 @@ class CodeControllerEndToEndTest @Autowired constructor(
 				else countVersions[code.code ?: "NO_CODE"]?.add(code.version ?: "NO_VERSION")
 			}
 		}
-		countVersions.forEach{ (k, v) ->
+		countVersions.forEach { (k, v) ->
 			codesStats["latest"] = (codesStats["latest"] as Map<String, String>) + (k to (v.maxOrNull() ?: "NO_VERSION"))
 		}
-
 	}
 
 	fun makeGetRequest(url: String): PaginatedList<CodeDto>? {
@@ -103,7 +102,7 @@ class CodeControllerEndToEndTest @Autowired constructor(
 		}.block()
 
 		assertNotNull(responseBody)
-		return objectMapper?.readValue(responseBody, object: TypeReference<PaginatedList<CodeDto>>() {})
+		return objectMapper?.readValue(responseBody, object : TypeReference<PaginatedList<CodeDto>>() {})
 	}
 
 	fun testPaginationFewResults(version: String, url: String, expectedRows: Int) {
@@ -223,13 +222,13 @@ class CodeControllerEndToEndTest @Autowired constructor(
 	fun testRegionVersionFilter() {
 		val region = "fr"
 		val version = "2"
-		testVersionSinglePage(version, (codesStats["count"] as Map<String, Int>)[version] ?: 0,"region=$region")
+		testVersionSinglePage(version, (codesStats["count"] as Map<String, Int>)[version] ?: 0, "region=$region")
 	}
 
 	@Test
 	fun testRegionVersionLatestFilter() {
 		val region = "fr"
-		testVersionSinglePage("latest", (codesStats["latest"] as Map<String, Int>).size,"region=$region")
+		testVersionSinglePage("latest", (codesStats["latest"] as Map<String, Int>).size, "region=$region")
 	}
 
 	//If I specify region, language and version, then I should get only results for that version
@@ -255,7 +254,7 @@ class CodeControllerEndToEndTest @Autowired constructor(
 		val language = "en"
 		val type = "testCode"
 		val version = "2"
-		testVersionSinglePage(version, (codesStats["count"] as Map<String, Int>)[version] ?: 0,"region=$region&language=$language&types=$type")
+		testVersionSinglePage(version, (codesStats["count"] as Map<String, Int>)[version] ?: 0, "region=$region&language=$language&types=$type")
 	}
 
 	@Test
@@ -263,7 +262,7 @@ class CodeControllerEndToEndTest @Autowired constructor(
 		val region = "fr"
 		val language = "en"
 		val type = "testCode"
-		testVersionSinglePage("latest", (codesStats["latest"] as Map<String, Int>).size,"region=$region&language=$language&types=$type")
+		testVersionSinglePage("latest", (codesStats["latest"] as Map<String, Int>).size, "region=$region&language=$language&types=$type")
 	}
 
 	//From now on, I just test with and without type, because is the only one that calls a different method
@@ -273,14 +272,14 @@ class CodeControllerEndToEndTest @Autowired constructor(
 	fun testVersionFilterPaginationFewResults() {
 		val version = "2"
 		val expectedRows = (codesStats["count"] as Map<String, Int>)[version] ?: 0
-		testPaginationFewResults(version, "$apiHost:$port$apiEndpoint?version=$version&limit=${expectedRows+2}", expectedRows)
+		testPaginationFewResults(version, "$apiHost:$port$apiEndpoint?version=$version&limit=${expectedRows + 2}", expectedRows)
 	}
 
 	@Test
 	fun testVersionLatestFilterPaginationFewResults() {
 		val version = "latest"
 		val expectedRows = (codesStats["latest"] as Map<String, Int>).size
-		testPaginationFewResults(version, "$apiHost:$port$apiEndpoint?version=$version&limit=${expectedRows+2}", expectedRows)
+		testPaginationFewResults(version, "$apiHost:$port$apiEndpoint?version=$version&limit=${expectedRows + 2}", expectedRows)
 	}
 
 	//If the number of elements in the db is less than the page size, all elements are in the same page
@@ -289,7 +288,7 @@ class CodeControllerEndToEndTest @Autowired constructor(
 		val version = "2"
 		val expectedRows = (codesStats["count"] as Map<String, Int>)[version] ?: 0
 		val type = "testCode"
-		testPaginationFewResults(version, "$apiHost:$port$apiEndpoint?version=$version&type=$type&limit=${expectedRows+2}", expectedRows)
+		testPaginationFewResults(version, "$apiHost:$port$apiEndpoint?version=$version&type=$type&limit=${expectedRows + 2}", expectedRows)
 	}
 
 	@Test
@@ -297,7 +296,7 @@ class CodeControllerEndToEndTest @Autowired constructor(
 		val version = "latest"
 		val expectedRows = (codesStats["latest"] as Map<String, Int>).size
 		val type = "testCode"
-		testPaginationFewResults(version, "$apiHost:$port$apiEndpoint?version=$version&type=$type&limit=${expectedRows+2}", expectedRows)
+		testPaginationFewResults(version, "$apiHost:$port$apiEndpoint?version=$version&type=$type&limit=${expectedRows + 2}", expectedRows)
 	}
 
 	//Test the pagination using only the version filter. The second page is not full
@@ -307,7 +306,7 @@ class CodeControllerEndToEndTest @Autowired constructor(
 		val expectedRows = (codesStats["count"] as Map<String, Int>)[version] ?: 0
 		assertEquals(expectedRows >= 4, true)
 		val limit: Int = (expectedRows / 2) + (expectedRows / 4)
-		testResultsOnTwoPages(version, "limit=$limit",limit, expectedRows-limit)
+		testResultsOnTwoPages(version, "limit=$limit", limit, expectedRows - limit)
 	}
 
 	@Test
@@ -315,9 +314,8 @@ class CodeControllerEndToEndTest @Autowired constructor(
 		val expectedRows = (codesStats["latest"] as Map<String, Int>).size
 		assertEquals(expectedRows >= 4, true)
 		val limit: Int = (expectedRows / 2) + (expectedRows / 4)
-		testResultsOnTwoPages("latest", "limit=$limit",limit, expectedRows-limit)
+		testResultsOnTwoPages("latest", "limit=$limit", limit, expectedRows - limit)
 	}
-
 
 	//Test the pagination using the version and type filter. The second page is not full
 	@Test
@@ -327,7 +325,7 @@ class CodeControllerEndToEndTest @Autowired constructor(
 		assertEquals(expectedRows >= 4, true)
 		val limit: Int = (expectedRows / 2) + (expectedRows / 4)
 		val type = "code"
-		testResultsOnTwoPages("2", "limit=$limit&types=$type", limit, expectedRows-limit)
+		testResultsOnTwoPages("2", "limit=$limit&types=$type", limit, expectedRows - limit)
 	}
 
 	@Test
@@ -336,7 +334,7 @@ class CodeControllerEndToEndTest @Autowired constructor(
 		assertEquals(expectedRows >= 4, true)
 		val limit: Int = (expectedRows / 2) + (expectedRows / 4)
 		val type = "code"
-		testResultsOnTwoPages("latest", "limit=$limit&types=$type", limit, expectedRows-limit)
+		testResultsOnTwoPages("latest", "limit=$limit&types=$type", limit, expectedRows - limit)
 	}
 
 	//Test the pagination using the version filter. The second page is full
@@ -344,28 +342,28 @@ class CodeControllerEndToEndTest @Autowired constructor(
 	fun testVersionFilterPaginationFewResultsSecondPageFull() {
 		var version: String? = null
 		var limit = 0
-		(codesStats["count"] as Map<String, Int>).forEach{ (k,v) ->
+		(codesStats["count"] as Map<String, Int>).forEach { (k, v) ->
 			if (v % 2 == 0) {
 				version = k
 				limit = v / 2
 			}
 		}
 		assertNotNull(version)
-		testResultsOnTwoPages(version!!, "limit=$limit",limit, limit)
+		testResultsOnTwoPages(version!!, "limit=$limit", limit, limit)
 	}
 
 	@Test
 	fun testVersionLatestFilterPaginationFewResultsSecondPageFull() {
 		val expectedRows = (codesStats["latest"] as Map<String, Int>).size
-		assertEquals(expectedRows%2, 0)
-		testResultsOnTwoPages("latest", "limit=${expectedRows/2}",expectedRows/2, expectedRows/2)
+		assertEquals(expectedRows % 2, 0)
+		testResultsOnTwoPages("latest", "limit=${expectedRows / 2}", expectedRows / 2, expectedRows / 2)
 	}
 
 	@Test
 	fun testVersionTypeFilterPaginationFewResultsSecondPageFull() {
 		var version: String? = null
 		var limit = 0
-		(codesStats["count"] as Map<String, Int>).forEach{ (k,v) ->
+		(codesStats["count"] as Map<String, Int>).forEach { (k, v) ->
 			if (v % 2 == 0) {
 				version = k
 				limit = v / 2
@@ -379,9 +377,9 @@ class CodeControllerEndToEndTest @Autowired constructor(
 	@Test
 	fun testVersionLatestTypeFilterPaginationFewResultsSecondPageFull() {
 		val expectedRows = (codesStats["latest"] as Map<String, Int>).size
-		assertEquals(expectedRows%2, 0)
+		assertEquals(expectedRows % 2, 0)
 		val type = "code"
-		testResultsOnTwoPages("latest", "limit=${expectedRows/2}&types=$type", expectedRows/2, expectedRows/2)
+		testResultsOnTwoPages("latest", "limit=${expectedRows / 2}&types=$type", expectedRows / 2, expectedRows / 2)
 	}
 
 	@AfterAll
@@ -390,6 +388,4 @@ class CodeControllerEndToEndTest @Autowired constructor(
 			removeEntities(codesStats["ids"] as List<String>, objectMapper)
 		}
 	}
-
-
 }

--- a/src/test/kotlin/org/taktik/icure/test/ICureTestApplication.kt
+++ b/src/test/kotlin/org/taktik/icure/test/ICureTestApplication.kt
@@ -118,7 +118,7 @@ class ICureTestApplication {
 	// At the end of the tests, I destroy the docker container
 	@PreDestroy
 	fun destroyDockerDBContainer() {
-		ProcessBuilder(("docker rm -f couchdb-test -v").split(' '))
+		ProcessBuilder(("docker rm -f couchdb-test-instance -v").split(' '))
 			.start()
 			.waitFor()
 	}

--- a/src/test/kotlin/org/taktik/icure/test/ICureTestApplication.kt
+++ b/src/test/kotlin/org/taktik/icure/test/ICureTestApplication.kt
@@ -2,7 +2,6 @@ package org.taktik.icure.test
 
 import javax.annotation.PreDestroy
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.reactive.awaitFirstOrNull
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.retry
 import kotlinx.coroutines.reactive.asFlow
@@ -77,11 +76,15 @@ class ICureTestApplication {
 				.block()
 		} catch (e: Exception) { // If not, I use docker to create a container
 			println("Starting docker")
-			ProcessBuilder(("docker run " +
-				"-p $dbPort:5984 " +
-				"-e COUCHDB_USER=${System.getenv("ICURE_COUCHDB_USERNAME")} -e COUCHDB_PASSWORD=${System.getenv("ICURE_COUCHDB_PASSWORD")} " +
-				"-d --name couchdb-test-instance " +
-				"couchdb:3.2.2").split(' '))
+			ProcessBuilder(
+				(
+					"docker run " +
+						"-p $dbPort:5984 " +
+						"-e COUCHDB_USER=${System.getenv("ICURE_COUCHDB_USERNAME")} -e COUCHDB_PASSWORD=${System.getenv("ICURE_COUCHDB_PASSWORD")} " +
+						"-d --name couchdb-test-instance " +
+						"couchdb:3.2.2"
+					).split(' ')
+			)
 				.start()
 				.waitFor()
 
@@ -109,7 +112,7 @@ class ICureTestApplication {
 				userLogic.newUser(Users.Type.database, System.getenv("ICURE_COUCHDB_TEST_USER"), System.getenv("ICURE_COUCHDB_TEST_PWD"), "icure")// Creates a test user if it does not exist
 			} catch (e: DuplicateDocumentException) {
 				log.info("Test user already exists!")
-			}finally {
+			} finally {
 				log.info("iCure test user\nusername: ${System.getenv("ICURE_COUCHDB_TEST_USER")}\npassword: ${System.getenv("ICURE_COUCHDB_TEST_PWD")}")
 			}
 		}

--- a/src/test/kotlin/org/taktik/icure/test/TestUtils.kt
+++ b/src/test/kotlin/org/taktik/icure/test/TestUtils.kt
@@ -1,5 +1,6 @@
 package org.taktik.icure.test
 
+import kotlin.math.abs
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import kotlin.random.Random.Default.nextInt
@@ -19,6 +20,18 @@ private data class IdWithRev(@field:JsonProperty("_id") val id: String, @field:J
 private fun generateRandomString(length: Int, alphabet: List<Char>) = (1..length)
 	.map { _ -> alphabet[nextInt(0, alphabet.size)] }
 	.joinToString("")
+
+@OptIn(ExperimentalStdlibApi::class)
+fun generateInBetweenCode(firstCode: String, secondCode: String): String {
+	val firstCodeLower = firstCode.lowercase()
+	val secondCodeLower = secondCode.lowercase()
+	return firstCodeLower.zip(secondCodeLower).fold("") { acc, it ->
+		if ( it.first == it.second || abs(it.first.toInt() - it.second.toInt()) == 1 ) acc + it.first
+		else acc + ((it.first.toInt() + it.second.toInt())/2).toChar()
+	}
+
+
+}
 
 suspend fun removeEntities(ids: List<String>, objectMapper: ObjectMapper?) {
 	val auth = "Basic ${java.util.Base64.getEncoder().encodeToString("${System.getenv("ICURE_COUCHDB_USERNAME")}:${System.getenv("ICURE_COUCHDB_PASSWORD")}".toByteArray())}"
@@ -46,7 +59,7 @@ suspend fun removeEntities(ids: List<String>, objectMapper: ObjectMapper?) {
 
 class CodeBatchGenerator {
 
-	private val alphabet: List<Char> = ('a'..'z').toList() + ('0'..'9')
+	private val alphabet: List<Char> = ('a'..'z').toList() + ('A'..'Z') + ('0'..'9')
 	private val languages = listOf("en", "fr", "nl")
 	private val types = listOf("SNOMED", "LOINC", "TESTCODE", "DEEPSECRET")
 	private val regions = listOf("int", "fr", "be")

--- a/src/test/kotlin/org/taktik/icure/test/TestUtils.kt
+++ b/src/test/kotlin/org/taktik/icure/test/TestUtils.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import kotlinx.coroutines.reactive.awaitFirstOrNull
+import org.taktik.icure.services.external.rest.v1.dto.CodeDto
 import org.taktik.icure.services.external.rest.v1.dto.UserDto
 import reactor.core.publisher.Mono
 import reactor.netty.http.client.HttpClient
@@ -41,6 +42,51 @@ suspend fun removeEntities(ids: List<String>, objectMapper: ObjectMapper?) {
 				} else Mono.empty()
 			}.awaitFirstOrNull()
 	}
+}
+
+class CodeBatchGenerator {
+
+	private val alphabet: List<Char> = ('a'..'z').toList() + ('0'..'9')
+	private val languages = listOf("en", "fr", "nl")
+	private val types = listOf("SNOMED", "LOINC", "TESTCODE", "DEEPSECRET")
+	private val regions = listOf("int", "fr", "be")
+
+	private fun generateRandomString(length: Int) = (1..length)
+		.map { _ -> alphabet[nextInt(0, alphabet.size)] }
+		.joinToString("")
+
+	fun createBatchOfUniqueCodes(size: Int) = (1..size)
+		.fold(listOf<CodeDto>()) { acc, _ ->
+			val lang = languages[nextInt(0, languages.size)]
+			val type = types[nextInt(0, types.size)]
+			val code = generateRandomString(20)
+			val version = nextInt(0, 10).toString()
+			acc + CodeDto(
+				id = "$type|$code|$version",
+				type = type,
+				code = code,
+				version = version,
+				label = if (nextInt(0, 4) == 0) mapOf(lang to generateRandomString(nextInt(20, 100))) else mapOf(),
+				regions = if (nextInt(0, 4) == 0) setOf(regions[nextInt(0, regions.size)]) else setOf(),
+				qualifiedLinks = if (nextInt(0, 4) == 0) mapOf(generateRandomString(10) to List(nextInt(1, 4)) { generateRandomString(10) }) else mapOf(),
+				searchTerms = if (nextInt(0, 4) == 0) mapOf(generateRandomString(10) to List(nextInt(1, 4)) { generateRandomString(10) }.toSet()) else mapOf(),
+			)
+		}
+
+	fun randomCodeModification(code: CodeDto, modifyLabel: Boolean = false, modifyRegions: Boolean = false, modifyQualifiedLinks: Boolean = false, modifySearchTerms: Boolean = false) = code
+		.let {
+			if (modifyLabel && nextInt(0, 4) == 0) it.copy(label = mapOf(languages[nextInt(0, languages.size)] to generateRandomString(nextInt(20, 100))))
+			else it
+		}.let {
+			if (modifyRegions && nextInt(0, 4) == 0) it.copy(regions = setOf(regions[nextInt(0, regions.size)]))
+			else it
+		}.let {
+			if (modifyQualifiedLinks && nextInt(0, 4) == 0) it.copy(qualifiedLinks = mapOf(generateRandomString(10) to List(nextInt(1, 4)) { generateRandomString(10) }))
+			else it
+		}.let {
+			if (modifySearchTerms && nextInt(0, 4) == 0) it.copy(searchTerms = mapOf(generateRandomString(10) to List(nextInt(1, 4)) { generateRandomString(10) }.toSet()))
+			else it
+		}
 }
 
 class UserGenerator {


### PR DESCRIPTION
Added the method to get the code ids in the CodeLogic and CodeDAO
Added the filter to get the code ids
Tested both CodeLogic and the filter for the following conditions:
- Neither start ComplexKey nor end ComplexKey specified, expected behaviour: all ids are included in the result
- Start ComplexKey specified but end ComplexKey not specified, expected behaviour: all the ids from start ComplexKey to end are included in the result
- Start ComplexKey not specified but end ComplexKey specified: all the ids from the beginning to end ComplexKey are included in the result
- Both start ComplexKey and end ComplexKey specified: all the ids from start ComplexKey to end ComplexKey are included in the result