### PR TITLE
Small fixes on maintenance tasks

### DIFF
--- a/src/main/kotlin/org/taktik/icure/asyncdao/MaintenanceTaskDAO.kt
+++ b/src/main/kotlin/org/taktik/icure/asyncdao/MaintenanceTaskDAO.kt
@@ -11,5 +11,5 @@ import org.taktik.icure.entities.embed.Identifier
 interface MaintenanceTaskDAO : GenericDAO<MaintenanceTask> {
 	fun listMaintenanceTasksByHcPartyAndIdentifier(healthcarePartyId: String, identifiers: List<Identifier>): Flow<String>
 	fun listMaintenanceTasksAfterDate(date: Long): Flow<String>
-	fun listMaintenanceTasksByHcPartyAndType(healthcarePartyId: String, type: String, startDate: Long, endDate: Long): Flow<String>
+	fun listMaintenanceTasksByHcPartyAndType(healthcarePartyId: String, type: String): Flow<String>
 }

--- a/src/main/kotlin/org/taktik/icure/asyncdao/impl/MaintenanceTaskDAOImpl.kt
+++ b/src/main/kotlin/org/taktik/icure/asyncdao/impl/MaintenanceTaskDAOImpl.kt
@@ -55,13 +55,18 @@ class MaintenanceTaskDAOImpl(
 	@View(name = "by_date", map = "function(doc) { if (doc.java_type === 'org.taktik.icure.entities.MaintenanceTask' && !doc.deleted) emit(doc.created)}")
 	override fun listMaintenanceTasksAfterDate(date: Long) = flow {
 		val client = couchDbDispatcher.getClient(dbInstanceUrl)
-		emitAll(client.queryView<Long, Void>(createQuery(client, "by_date").startKey(999999999999L).endKey(date).descending(true).includeDocs(false)).map { it.id })
+		emitAll(client.queryView<Long, Void>(createQuery(client, "by_date").endKey(date).descending(true).includeDocs(false)).map { it.id })
 	}
 
 	@OptIn(ExperimentalCoroutinesApi::class)
-	@View(name = "by_type", map = "function(doc) { if (doc.java_type === 'org.taktik.icure.entities.MaintenanceTask' && !doc.deleted && doc.type) emit([doc.type,doc.created])}")
-	override fun listMaintenanceTasksByHcPartyAndType(healthcarePartyId: String, type: String, startDate: Long, endDate: Long) = flow {
+	@View(name = "by_hcparty_type", map = "classpath:js/maintenancetask/By_hcparty_type_map.js")
+	override fun listMaintenanceTasksByHcPartyAndType(healthcarePartyId: String, type: String) = flow {
 		val client = couchDbDispatcher.getClient(dbInstanceUrl)
-		emitAll(client.queryView<ComplexKey, Void>(createQuery(client, "by_date").startKey(ComplexKey.of(type, startDate)).endKey(ComplexKey.of(type, endDate)).descending(true).includeDocs(false)).map { it.id })
+
+		val queryView = createQuery(client, "by_hcparty_type")
+			.keys(listOf(ComplexKey.of(healthcarePartyId, type)))
+			.includeDocs(false)
+
+		emitAll(client.queryView<ComplexKey, Void>(queryView).map { it.id })
 	}
 }

--- a/src/main/kotlin/org/taktik/icure/asynclogic/MaintenanceTaskLogic.kt
+++ b/src/main/kotlin/org/taktik/icure/asynclogic/MaintenanceTaskLogic.kt
@@ -13,7 +13,7 @@ import org.taktik.icure.entities.embed.Identifier
 
 interface MaintenanceTaskLogic : EntityPersister<MaintenanceTask, String> {
 	fun listMaintenanceTasksByHcPartyAndIdentifier(healthcarePartyId: String, identifiers: List<Identifier>): Flow<String>
-	fun listMaintenanceTasksByHcPartyAndType(healthcarePartyId: String, type: String, startDate: Long, endDate: Long): Flow<String>
+	fun listMaintenanceTasksByHcPartyAndType(healthcarePartyId: String, type: String): Flow<String>
 	fun listMaintenanceTasksAfterDate(date: Long): Flow<String>
 
 	fun getGenericDAO(): MaintenanceTaskDAO

--- a/src/main/kotlin/org/taktik/icure/asynclogic/impl/MaintenanceTaskLogicImpl.kt
+++ b/src/main/kotlin/org/taktik/icure/asynclogic/impl/MaintenanceTaskLogicImpl.kt
@@ -33,8 +33,8 @@ class MaintenanceTaskLogicImpl(
 		emitAll(maintenanceTaskDAO.listMaintenanceTasksByHcPartyAndIdentifier(healthcarePartyId, identifiers))
 	}
 
-	override fun listMaintenanceTasksByHcPartyAndType(healthcarePartyId: String, type: String, startDate: Long, endDate: Long): Flow<String> = flow {
-		emitAll(maintenanceTaskDAO.listMaintenanceTasksByHcPartyAndType(healthcarePartyId, type, startDate, endDate))
+	override fun listMaintenanceTasksByHcPartyAndType(healthcarePartyId: String, type: String): Flow<String> = flow {
+		emitAll(maintenanceTaskDAO.listMaintenanceTasksByHcPartyAndType(healthcarePartyId, type))
 	}
 
 	override fun listMaintenanceTasksAfterDate(date: Long): Flow<String> = flow {
@@ -58,8 +58,11 @@ class MaintenanceTaskLogicImpl(
 			)
 		}
 
-
 	override fun getGenericDAO(): MaintenanceTaskDAO {
 		return maintenanceTaskDAO
+	}
+
+	override fun createEntities(entities: Collection<MaintenanceTask>) = flow {
+		emitAll( super.createEntities(entities.map { fix(it) }) )
 	}
 }

--- a/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/maintenancetask/MaintenanceTaskByHcPartyAndTypeFilter.kt
+++ b/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/maintenancetask/MaintenanceTaskByHcPartyAndTypeFilter.kt
@@ -25,7 +25,7 @@ class MaintenanceTaskByHcPartyAndTypeFilter(
 
 	override fun resolve(filter: MaintenanceTaskByHcPartyAndTypeFilter, context: Filters) = flow<String> {
 		try {
-			emitAll(maintenanceTaskLogic.listMaintenanceTasksByHcPartyAndType(filter.healthcarePartyId ?: getLoggedHealthCarePartyId(sessionLogic), filter.type, 0L, 99993112000000L))
+			emitAll(maintenanceTaskLogic.listMaintenanceTasksByHcPartyAndType(filter.healthcarePartyId ?: getLoggedHealthCarePartyId(sessionLogic), filter.type))
 		} catch (e: LoginException) {
 			throw IllegalArgumentException(e)
 		}

--- a/src/main/resources/org/taktik/icure/asyncdao/impl/js/maintenancetask/By_hcparty_type_map.js
+++ b/src/main/resources/org/taktik/icure/asyncdao/impl/js/maintenancetask/By_hcparty_type_map.js
@@ -1,0 +1,9 @@
+map = function(doc) {
+	if (doc.java_type === 'org.taktik.icure.entities.MaintenanceTask' && !doc.deleted && doc.taskType) {
+		if (doc.delegations) {
+			Object.keys(doc.delegations).forEach(function (d) {
+				emit([d, doc.taskType])
+			});
+		}
+	}
+}

--- a/src/test/kotlin/org/taktik/icure/asynclogic/impl/filter/maintenancetask/MaintenanceTaskAfterDateFilterTest.kt
+++ b/src/test/kotlin/org/taktik/icure/asynclogic/impl/filter/maintenancetask/MaintenanceTaskAfterDateFilterTest.kt
@@ -1,0 +1,101 @@
+package org.taktik.icure.asynclogic.impl.filter.maintenancetask
+
+import kotlin.random.Random
+import kotlin.random.Random.Default.nextInt
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.SingletonSupport
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.count
+import kotlinx.coroutines.flow.fold
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.taktik.icure.asynclogic.MaintenanceTaskLogic
+import org.taktik.icure.asynclogic.impl.filter.Filters
+import org.taktik.icure.services.external.rest.v1.dto.MaintenanceTaskDto
+import org.taktik.icure.services.external.rest.v1.dto.embed.TaskStatusDto
+import org.taktik.icure.services.external.rest.v1.mapper.MaintenanceTaskMapper
+import org.taktik.icure.test.ICureTestApplication
+import org.taktik.icure.test.generateRandomString
+import org.taktik.icure.test.removeEntities
+import org.taktik.icure.services.external.rest.v1.dto.filter.maintenancetask.MaintenanceTaskAfterDateFilter
+
+@SpringBootTest(
+	classes = [ICureTestApplication::class],
+	properties = ["spring.main.allow-bean-definition-overriding=true"],
+	webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+@ActiveProfiles("app")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MaintenanceTaskAfterDateFilterTest @Autowired constructor(
+	private val filters: Filters,
+	private val maintenanceTaskLogic: MaintenanceTaskLogic,
+	private val maintenanceTaskMapper: MaintenanceTaskMapper
+) {
+
+	private val testBatch = 10
+	private val currentTimestamp = System.currentTimeMillis()
+	private val alphabet: List<Char> = ('a'..'z').toList() + ('A'..'Z') + ('0'..'9')
+	private var taskIds: List<String> = listOf()
+
+	@BeforeAll
+	fun importMaintenanceTasks() {
+		runBlocking {
+			val taskIdsBefore = (1..testBatch).fold(listOf<String>()) { acc, _ ->
+				val taskId = generateRandomString(20, alphabet)
+				val newTask = MaintenanceTaskDto(
+					id = taskId,
+					created = currentTimestamp - nextInt(100, 10000),
+					status = TaskStatusDto.pending
+				)
+				maintenanceTaskLogic.createEntities(listOf(maintenanceTaskMapper.map(newTask))).collect()
+				acc + taskId
+			}
+			taskIds = (1..testBatch).fold(taskIdsBefore) { acc, _ ->
+				val taskId = generateRandomString(20, alphabet)
+				val newTask = MaintenanceTaskDto(
+					id = taskId,
+					created = currentTimestamp + nextInt(100, 10000),
+					status = TaskStatusDto.pending
+				)
+				maintenanceTaskLogic.createEntities(listOf(maintenanceTaskMapper.map(newTask))).collect()
+				acc + taskId
+			}
+		}
+	}
+
+	@Test
+	fun onlyTasksCreatedAfterTheDateSpecifiedInTheFilterAreReturned() {
+		runBlocking {
+			val dateFilter = MaintenanceTaskAfterDateFilter(date = currentTimestamp)
+			val filteredTasks = filters.resolve(dateFilter).count()
+			assertEquals(testBatch, filteredTasks)
+		}
+	}
+
+	@AfterAll
+	fun cleanTasks() {
+		runBlocking {
+			val objectMapper = ObjectMapper().registerModule(
+				KotlinModule.Builder()
+					.nullIsSameAsDefault(nullIsSameAsDefault = false)
+					.reflectionCacheSize(reflectionCacheSize = 512)
+					.nullToEmptyMap(nullToEmptyMap = false)
+					.nullToEmptyCollection(nullToEmptyCollection = false)
+					.singletonSupport(singletonSupport = SingletonSupport.DISABLED)
+					.strictNullChecks(strictNullChecks = false)
+					.build()
+			)
+			removeEntities(taskIds, objectMapper)
+		}
+	}
+
+}

--- a/src/test/kotlin/org/taktik/icure/asynclogic/impl/filter/maintenancetask/MaintenanceTaskAfterDateFilterTest.kt
+++ b/src/test/kotlin/org/taktik/icure/asynclogic/impl/filter/maintenancetask/MaintenanceTaskAfterDateFilterTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -76,8 +77,14 @@ class MaintenanceTaskAfterDateFilterTest @Autowired constructor(
 	fun onlyTasksCreatedAfterTheDateSpecifiedInTheFilterAreReturned() {
 		runBlocking {
 			val dateFilter = MaintenanceTaskAfterDateFilter(date = currentTimestamp)
-			val filteredTasks = filters.resolve(dateFilter).count()
-			assertEquals(testBatch, filteredTasks)
+			val filteredTasksCount = filters.resolve(dateFilter).fold(0) { acc, taskId ->
+				val task = maintenanceTaskLogic.getEntity(taskId)
+				assertNotNull(task)
+				assertNotNull(task!!.created)
+				assert(task.created!! > currentTimestamp)
+				acc + 1
+			}
+			assertEquals(testBatch, filteredTasksCount)
 		}
 	}
 

--- a/src/test/kotlin/org/taktik/icure/test/TestUtils.kt
+++ b/src/test/kotlin/org/taktik/icure/test/TestUtils.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import kotlinx.coroutines.reactive.awaitFirstOrNull
+import org.taktik.icure.services.external.rest.v1.dto.MaintenanceTaskDto
 import org.taktik.icure.services.external.rest.v1.dto.UserDto
 import reactor.core.publisher.Mono
 import reactor.netty.http.client.HttpClient
@@ -15,7 +16,7 @@ import reactor.netty.http.client.HttpClient
 @JsonIgnoreProperties(ignoreUnknown = true)
 private data class IdWithRev(@field:JsonProperty("_id") val id: String, @field:JsonProperty("_rev") val rev: String)
 
-private fun generateRandomString(length: Int, alphabet: List<Char>) = (1..length)
+fun generateRandomString(length: Int, alphabet: List<Char>) = (1..length)
 	.map { _ -> alphabet[nextInt(0, alphabet.size)] }
 	.joinToString("")
 
@@ -46,6 +47,7 @@ suspend fun removeEntities(ids: List<String>, objectMapper: ObjectMapper?) {
 class UserGenerator {
 
 	private val alphabet: List<Char> = ('a'..'z').toList() + ('A'..'Z') + ('0'..'9')
+
 	fun generateRandomUsers(num: Int) = List(num) {
 		UserDto(
 			id = generateRandomString(20, alphabet),


### PR DESCRIPTION
Added fix method on MaintenanceTask creation

Fixed some bugs on ByHcPAndTypeFilter:
- The wrong view was called during filtering
- The view included type and date instead of healthcare party and type

Fixed a bug on CreatedAfterDateFilter:
- By using the startKey 9999999999L, no row was returned