### PR TITLE
Fixed mapper for CodeIdsByTypeCodeVersionIntervalFilter and UsersByPatientIdFilter

### DIFF
--- a/src/main/kotlin/org/taktik/icure/domain/filter/impl/code/CodeIdsByTypeCodeVersionIntervalFilter.kt
+++ b/src/main/kotlin/org/taktik/icure/domain/filter/impl/code/CodeIdsByTypeCodeVersionIntervalFilter.kt
@@ -1,0 +1,30 @@
+package org.taktik.icure.domain.filter.impl.code
+
+import com.github.pozo.KotlinBuilder
+import org.taktik.icure.domain.filter.AbstractFilter
+import org.taktik.icure.entities.base.Code
+
+@KotlinBuilder
+data class CodeIdsByTypeCodeVersionIntervalFilter (
+	override val desc: String?,
+	override val startType: String?,
+	override val startCode: String?,
+	override val startVersion: String?,
+	override val endType: String?,
+	override val endCode: String?,
+	override val endVersion: String?
+) : AbstractFilter<Code>, org.taktik.icure.domain.filter.code.CodeIdsByTypeCodeVersionIntervalFilter {
+
+	override fun matches(item: Code): Boolean {
+		val typeCondition = item.type != null &&
+			(startType == null || item.type >= startType) &&
+			(endType == null || item.type <= endType)
+		val codeCondition = item.code != null &&
+			(startCode == null || item.code >= startCode) &&
+			(endCode == null || item.code <= endCode)
+		val versionCondition = item.version != null &&
+			(startVersion == null || item.version >= startVersion) &&
+			(endVersion == null || item.version <= endVersion)
+		return typeCondition && codeCondition && versionCondition;
+	}
+}

--- a/src/main/kotlin/org/taktik/icure/domain/filter/impl/user/UsersByPatientIdFilter.kt
+++ b/src/main/kotlin/org/taktik/icure/domain/filter/impl/user/UsersByPatientIdFilter.kt
@@ -1,0 +1,18 @@
+package org.taktik.icure.domain.filter.impl.user
+
+import com.github.pozo.KotlinBuilder
+import org.taktik.icure.domain.filter.AbstractFilter
+import org.taktik.icure.entities.User
+
+@KotlinBuilder
+data class UsersByPatientIdFilter(
+	override val desc: String?,
+	override val patientId: String
+) : AbstractFilter<User>, org.taktik.icure.domain.filter.user.UsersByPatientIdFilter {
+
+	override fun matches(item: User): Boolean {
+		return item.patientId != null &&
+				patientId == item.patientId
+	}
+
+}

--- a/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/filter/FilterMapper.kt
+++ b/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/filter/FilterMapper.kt
@@ -34,6 +34,7 @@ import org.taktik.icure.services.external.rest.v1.dto.filter.UnionFilter
 import org.taktik.icure.services.external.rest.v1.dto.filter.code.AllCodesFilter
 import org.taktik.icure.services.external.rest.v1.dto.filter.code.CodeByIdsFilter
 import org.taktik.icure.services.external.rest.v1.dto.filter.code.CodeByRegionTypeLabelLanguageFilter
+import org.taktik.icure.services.external.rest.v1.dto.filter.code.CodeIdsByTypeCodeVersionIntervalFilter
 import org.taktik.icure.services.external.rest.v1.dto.filter.contact.ContactByHcPartyFilter
 import org.taktik.icure.services.external.rest.v1.dto.filter.contact.ContactByHcPartyIdentifiersFilter
 import org.taktik.icure.services.external.rest.v1.dto.filter.contact.ContactByHcPartyPatientTagCodeDateFilter
@@ -80,11 +81,13 @@ import org.taktik.icure.services.external.rest.v1.dto.filter.service.ServiceBySe
 import org.taktik.icure.services.external.rest.v1.dto.filter.user.AllUsersFilter
 import org.taktik.icure.services.external.rest.v1.dto.filter.user.UserByIdsFilter
 import org.taktik.icure.services.external.rest.v1.dto.filter.user.UserByNameEmailPhoneFilter
+import org.taktik.icure.services.external.rest.v1.dto.filter.user.UsersByPatientIdFilter
 
 @ExperimentalStdlibApi
 @Mapper(componentModel = "spring", uses = [], injectionStrategy = InjectionStrategy.CONSTRUCTOR)
 abstract class FilterMapper {
 	abstract fun map(filterDto: CodeByRegionTypeLabelLanguageFilter): org.taktik.icure.domain.filter.impl.code.CodeByRegionTypeLabelLanguageFilter
+	abstract fun map(filterDto: CodeIdsByTypeCodeVersionIntervalFilter): org.taktik.icure.domain.filter.impl.code.CodeIdsByTypeCodeVersionIntervalFilter
 	abstract fun map(filterDto: ContactByHcPartyPatientTagCodeDateFilter): org.taktik.icure.domain.filter.impl.contact.ContactByHcPartyPatientTagCodeDateFilter
 	abstract fun map(filterDto: ContactByHcPartyTagCodeDateFilter): org.taktik.icure.domain.filter.impl.contact.ContactByHcPartyTagCodeDateFilter
 	abstract fun map(filterDto: ContactByServiceIdsFilter): org.taktik.icure.domain.filter.impl.contact.ContactByServiceIdsFilter
@@ -133,6 +136,7 @@ abstract class FilterMapper {
 	abstract fun map(filterDto: ServiceByIdsFilter): org.taktik.icure.domain.filter.impl.service.ServiceByIdsFilter
 	abstract fun map(filterDto: UserByIdsFilter): org.taktik.icure.domain.filter.impl.user.UserByIdsFilter
 	abstract fun map(filterDto: UserByNameEmailPhoneFilter): org.taktik.icure.domain.filter.impl.user.UserByNameEmailPhoneFilter
+	abstract fun map(filterDto: UsersByPatientIdFilter): org.taktik.icure.domain.filter.impl.user.UsersByPatientIdFilter
 
 	fun <O : Identifiable<String>> mapToDto(filterDto: UnionFilter<O>): org.taktik.icure.domain.filter.impl.UnionFilter<O> {
 		val filters: List<AbstractFilter<O>> = filterDto.filters.map { map(it) as AbstractFilter<O> }
@@ -161,6 +165,7 @@ abstract class FilterMapper {
 	fun map(filterDto: AbstractFilterDto<*>): AbstractFilter<*> {
 		return when (filterDto) {
 			is CodeByRegionTypeLabelLanguageFilter -> map(filterDto)
+			is CodeIdsByTypeCodeVersionIntervalFilter -> map(filterDto)
 			is ContactByHcPartyPatientTagCodeDateFilter -> map(filterDto)
 			is ContactByHcPartyTagCodeDateFilter -> map(filterDto)
 			is ContactByServiceIdsFilter -> map(filterDto)
@@ -212,6 +217,7 @@ abstract class FilterMapper {
 			is ServiceByIdsFilter -> map(filterDto)
 			is UserByIdsFilter -> map(filterDto)
 			is UserByNameEmailPhoneFilter -> map(filterDto)
+			is UsersByPatientIdFilter -> map(filterDto)
 			else -> throw IllegalArgumentException("Unsupported filter class")
 		}
 	}
@@ -293,6 +299,7 @@ abstract class FilterMapper {
 	fun map(filter: AbstractFilter<*>): AbstractFilterDto<*> {
 		return when (filter) {
 			is org.taktik.icure.domain.filter.impl.code.CodeByRegionTypeLabelLanguageFilter -> map(filter)
+			is org.taktik.icure.domain.filter.impl.code.CodeIdsByTypeCodeVersionIntervalFilter -> map(filter)
 			is org.taktik.icure.domain.filter.impl.contact.ContactByHcPartyPatientTagCodeDateFilter -> map(filter)
 			is org.taktik.icure.domain.filter.impl.contact.ContactByHcPartyTagCodeDateFilter -> map(filter)
 			is org.taktik.icure.domain.filter.impl.contact.ContactByServiceIdsFilter -> map(filter)
@@ -346,6 +353,7 @@ abstract class FilterMapper {
 			is org.taktik.icure.domain.filter.impl.service.ServiceByIdsFilter -> map(filter)
 			is org.taktik.icure.domain.filter.impl.user.UserByIdsFilter -> map(filter)
 			is org.taktik.icure.domain.filter.impl.user.UserByNameEmailPhoneFilter -> map(filter)
+			is org.taktik.icure.domain.filter.impl.user.UsersByPatientIdFilter -> map(filter)
 			else -> throw IllegalArgumentException("Unsupported filter class")
 		}
 	}

--- a/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/filter/FilterMapper.kt
+++ b/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/filter/FilterMapper.kt
@@ -223,6 +223,7 @@ abstract class FilterMapper {
 	}
 
 	abstract fun map(filter: org.taktik.icure.domain.filter.impl.code.CodeByRegionTypeLabelLanguageFilter): CodeByRegionTypeLabelLanguageFilter
+	abstract fun map(filter: org.taktik.icure.domain.filter.impl.code.CodeIdsByTypeCodeVersionIntervalFilter): CodeIdsByTypeCodeVersionIntervalFilter
 	abstract fun map(filter: org.taktik.icure.domain.filter.impl.contact.ContactByHcPartyPatientTagCodeDateFilter): ContactByHcPartyPatientTagCodeDateFilter
 	abstract fun map(filter: org.taktik.icure.domain.filter.impl.contact.ContactByHcPartyTagCodeDateFilter): ContactByHcPartyTagCodeDateFilter
 	abstract fun map(filter: org.taktik.icure.domain.filter.impl.contact.ContactByServiceIdsFilter): ContactByServiceIdsFilter
@@ -271,6 +272,7 @@ abstract class FilterMapper {
 	abstract fun map(filter: org.taktik.icure.domain.filter.impl.service.ServiceByIdsFilter): ServiceByIdsFilter
 	abstract fun map(filter: org.taktik.icure.domain.filter.impl.user.UserByIdsFilter): UserByIdsFilter
 	abstract fun map(filter: org.taktik.icure.domain.filter.impl.user.UserByNameEmailPhoneFilter): UserByNameEmailPhoneFilter
+	abstract fun map(filter: org.taktik.icure.domain.filter.impl.user.UsersByPatientIdFilter): UsersByPatientIdFilter
 
 	fun <O : Identifiable<String>> mapToDomain(filterDto: org.taktik.icure.domain.filter.impl.UnionFilter<O>): UnionFilter<O> {
 		val filters: List<AbstractFilterDto<O>> = filterDto.filters.map { map(it) as AbstractFilterDto<O> }

--- a/src/main/kotlin/org/taktik/icure/services/external/rest/v2/mapper/filter/FilterMapper.kt
+++ b/src/main/kotlin/org/taktik/icure/services/external/rest/v2/mapper/filter/FilterMapper.kt
@@ -223,6 +223,7 @@ abstract class FilterV2Mapper {
 	}
 
 	abstract fun map(filter: org.taktik.icure.domain.filter.impl.code.CodeByRegionTypeLabelLanguageFilter): CodeByRegionTypeLabelLanguageFilter
+	abstract fun map(filter: org.taktik.icure.domain.filter.impl.code.CodeIdsByTypeCodeVersionIntervalFilter): CodeIdsByTypeCodeVersionIntervalFilter
 	abstract fun map(filter: org.taktik.icure.domain.filter.impl.contact.ContactByHcPartyPatientTagCodeDateFilter): ContactByHcPartyPatientTagCodeDateFilter
 	abstract fun map(filter: org.taktik.icure.domain.filter.impl.contact.ContactByHcPartyTagCodeDateFilter): ContactByHcPartyTagCodeDateFilter
 	abstract fun map(filter: org.taktik.icure.domain.filter.impl.contact.ContactByServiceIdsFilter): ContactByServiceIdsFilter
@@ -271,6 +272,7 @@ abstract class FilterV2Mapper {
 	abstract fun map(filter: org.taktik.icure.domain.filter.impl.service.ServiceByIdsFilter): ServiceByIdsFilter
 	abstract fun map(filter: org.taktik.icure.domain.filter.impl.user.UserByIdsFilter): UserByIdsFilter
 	abstract fun map(filter: org.taktik.icure.domain.filter.impl.user.UserByNameEmailPhoneFilter): UserByNameEmailPhoneFilter
+	abstract fun map(filter: org.taktik.icure.domain.filter.impl.user.UsersByPatientIdFilter): UsersByPatientIdFilter
 
 	fun <O : Identifiable<String>> mapToDomain(filterDto: org.taktik.icure.domain.filter.impl.UnionFilter<O>): UnionFilter<O> {
 		val filters: List<AbstractFilterDto<O>> = filterDto.filters.map { map(it) as AbstractFilterDto<O> }

--- a/src/main/kotlin/org/taktik/icure/services/external/rest/v2/mapper/filter/FilterMapper.kt
+++ b/src/main/kotlin/org/taktik/icure/services/external/rest/v2/mapper/filter/FilterMapper.kt
@@ -34,6 +34,7 @@ import org.taktik.icure.services.external.rest.v2.dto.filter.UnionFilter
 import org.taktik.icure.services.external.rest.v2.dto.filter.code.AllCodesFilter
 import org.taktik.icure.services.external.rest.v2.dto.filter.code.CodeByIdsFilter
 import org.taktik.icure.services.external.rest.v2.dto.filter.code.CodeByRegionTypeLabelLanguageFilter
+import org.taktik.icure.services.external.rest.v2.dto.filter.code.CodeIdsByTypeCodeVersionIntervalFilter
 import org.taktik.icure.services.external.rest.v2.dto.filter.contact.ContactByHcPartyFilter
 import org.taktik.icure.services.external.rest.v2.dto.filter.contact.ContactByHcPartyIdentifiersFilter
 import org.taktik.icure.services.external.rest.v2.dto.filter.contact.ContactByHcPartyPatientTagCodeDateFilter
@@ -80,11 +81,13 @@ import org.taktik.icure.services.external.rest.v2.dto.filter.service.ServiceBySe
 import org.taktik.icure.services.external.rest.v2.dto.filter.user.AllUsersFilter
 import org.taktik.icure.services.external.rest.v2.dto.filter.user.UserByIdsFilter
 import org.taktik.icure.services.external.rest.v2.dto.filter.user.UserByNameEmailPhoneFilter
+import org.taktik.icure.services.external.rest.v2.dto.filter.user.UsersByPatientIdFilter
 
 @ExperimentalStdlibApi
 @Mapper(componentModel = "spring", uses = [], injectionStrategy = InjectionStrategy.CONSTRUCTOR)
 abstract class FilterV2Mapper {
 	abstract fun map(filterDto: CodeByRegionTypeLabelLanguageFilter): org.taktik.icure.domain.filter.impl.code.CodeByRegionTypeLabelLanguageFilter
+	abstract fun map(filterDto: CodeIdsByTypeCodeVersionIntervalFilter): org.taktik.icure.domain.filter.impl.code.CodeIdsByTypeCodeVersionIntervalFilter
 	abstract fun map(filterDto: ContactByHcPartyPatientTagCodeDateFilter): org.taktik.icure.domain.filter.impl.contact.ContactByHcPartyPatientTagCodeDateFilter
 	abstract fun map(filterDto: ContactByHcPartyTagCodeDateFilter): org.taktik.icure.domain.filter.impl.contact.ContactByHcPartyTagCodeDateFilter
 	abstract fun map(filterDto: ContactByServiceIdsFilter): org.taktik.icure.domain.filter.impl.contact.ContactByServiceIdsFilter
@@ -133,6 +136,7 @@ abstract class FilterV2Mapper {
 	abstract fun map(filterDto: ServiceByIdsFilter): org.taktik.icure.domain.filter.impl.service.ServiceByIdsFilter
 	abstract fun map(filterDto: UserByIdsFilter): org.taktik.icure.domain.filter.impl.user.UserByIdsFilter
 	abstract fun map(filterDto: UserByNameEmailPhoneFilter): org.taktik.icure.domain.filter.impl.user.UserByNameEmailPhoneFilter
+	abstract fun map(filterDto: UsersByPatientIdFilter): org.taktik.icure.domain.filter.impl.user.UsersByPatientIdFilter
 
 	fun <O : Identifiable<String>> mapToDto(filterDto: UnionFilter<O>): org.taktik.icure.domain.filter.impl.UnionFilter<O> {
 		val filters: List<AbstractFilter<O>> = filterDto.filters.map { map(it) as AbstractFilter<O> }
@@ -161,6 +165,7 @@ abstract class FilterV2Mapper {
 	fun map(filterDto: AbstractFilterDto<*>): AbstractFilter<*> {
 		return when (filterDto) {
 			is CodeByRegionTypeLabelLanguageFilter -> map(filterDto)
+			is CodeIdsByTypeCodeVersionIntervalFilter -> map(filterDto)
 			is ContactByHcPartyPatientTagCodeDateFilter -> map(filterDto)
 			is ContactByHcPartyTagCodeDateFilter -> map(filterDto)
 			is ContactByServiceIdsFilter -> map(filterDto)
@@ -212,6 +217,7 @@ abstract class FilterV2Mapper {
 			is ServiceByIdsFilter -> map(filterDto)
 			is UserByIdsFilter -> map(filterDto)
 			is UserByNameEmailPhoneFilter -> map(filterDto)
+			is UsersByPatientIdFilter -> map(filterDto)
 			else -> throw IllegalArgumentException("Unsupported filter class")
 		}
 	}
@@ -293,6 +299,7 @@ abstract class FilterV2Mapper {
 	fun map(filter: AbstractFilter<*>): AbstractFilterDto<*> {
 		return when (filter) {
 			is org.taktik.icure.domain.filter.impl.code.CodeByRegionTypeLabelLanguageFilter -> map(filter)
+			is org.taktik.icure.domain.filter.impl.code.CodeIdsByTypeCodeVersionIntervalFilter -> map(filter)
 			is org.taktik.icure.domain.filter.impl.contact.ContactByHcPartyPatientTagCodeDateFilter -> map(filter)
 			is org.taktik.icure.domain.filter.impl.contact.ContactByHcPartyTagCodeDateFilter -> map(filter)
 			is org.taktik.icure.domain.filter.impl.contact.ContactByServiceIdsFilter -> map(filter)
@@ -346,6 +353,7 @@ abstract class FilterV2Mapper {
 			is org.taktik.icure.domain.filter.impl.service.ServiceByIdsFilter -> map(filter)
 			is org.taktik.icure.domain.filter.impl.user.UserByIdsFilter -> map(filter)
 			is org.taktik.icure.domain.filter.impl.user.UserByNameEmailPhoneFilter -> map(filter)
+			is org.taktik.icure.domain.filter.impl.user.UsersByPatientIdFilter -> map(filter)
 			else -> throw IllegalArgumentException("Unsupported filter class")
 		}
 	}

--- a/src/test/kotlin/org/taktik/icure/asynclogic/impl/filter/code/CodeIdsByTypeCodeVersionIntervalFilterTest.kt
+++ b/src/test/kotlin/org/taktik/icure/asynclogic/impl/filter/code/CodeIdsByTypeCodeVersionIntervalFilterTest.kt
@@ -79,7 +79,7 @@ class CodeIdsByTypeCodeVersionIntervalFilterTest @Autowired constructor(
 	}
 
 	@Test
-	fun ifEndKeyIsSpecifiedOnlyResultsThatComeAfterAreReturned() {
+	fun ifEndKeyIsSpecifiedOnlyResultsThatComeBeforeAreReturned() {
 		runBlocking {
 			val endIndex = Random.nextInt(0, testBatchIds.size)
 			val endCode = testBatch[testBatchIds[endIndex]]!!


### PR DESCRIPTION
The CodeIdsByTypeCodeVersionIntervalFilter and UsersByPatientIdFilter were not added to the mapper class and so they were not usable by the controllers.